### PR TITLE
Removed turbolinks

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,6 @@ gem 'pg', '>= 0.18', '< 2.0'
 gem 'puma', '~> 4.1'
 gem 'sass-rails', '>= 6'
 gem 'webpacker', '~> 4.0'
-gem 'turbolinks', '~> 5'
 gem 'redis', '~> 4.0'
 gem 'bcrypt', '~> 3.1.7'
 gem 'bootsnap', '>= 1.4.2', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -157,9 +157,6 @@ GEM
     thor (1.0.1)
     thread_safe (0.3.6)
     tilt (2.0.10)
-    turbolinks (5.2.1)
-      turbolinks-source (~> 5.2)
-    turbolinks-source (5.2.0)
     tzinfo (1.2.7)
       thread_safe (~> 0.1)
     web-console (4.0.4)
@@ -191,7 +188,6 @@ DEPENDENCIES
   sass-rails (>= 6)
   spring
   spring-watcher-listen (~> 2.0.0)
-  turbolinks (~> 5)
   tzinfo-data
   web-console (>= 3.3.0)
   webpacker (~> 4.0)

--- a/app/controllers/programs_controller.rb
+++ b/app/controllers/programs_controller.rb
@@ -4,7 +4,7 @@ class ProgramsController < ApplicationController
   def show
     program = Program.includes(:chars).find(params.fetch(:id))
     
-    if request.xhr?
+    if request.headers["HTTP_RESPONSE_TYPE"] == "json"
       render json: view(program)
     else
       render :show

--- a/app/javascript/components/Program.js
+++ b/app/javascript/components/Program.js
@@ -14,8 +14,6 @@ const Program = () => {
   const [program, setProgram] = useState({});
   const [addition, setAddition] = useState("");
   
-  console.log(window.location);
-
   useEffect(() => {
     const programId = window.location.pathname.split("/")[2]
     const url = `/programs/${programId}`;
@@ -55,8 +53,9 @@ const Program = () => {
     client.put(url, data)
       .then(response => response.json())
       .then(response => setProgram(response));
-  }
+  };
 
+  if (!program.id) return "";
   return (
     <>
       <h1>{`${program.name} - ${program.mode}`}</h1>

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -4,7 +4,6 @@
 // that code so it'll be compiled.
 
 require("@rails/ujs").start()
-require("turbolinks").start()
 require("@rails/activestorage").start()
 require("channels")
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -5,8 +5,8 @@
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
 
-    <%= stylesheet_link_tag :application, media: :all, 'data-turbolinks-track': :reload %>
-    <%= javascript_pack_tag :application, 'data-turbolinks-track': :reload %>
+    <%= stylesheet_link_tag :application, media: :all %>
+    <%= javascript_pack_tag :application %>
   </head>
 
   <body>

--- a/package.json
+++ b/package.json
@@ -11,8 +11,7 @@
     "prop-types": "^15.7.2",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
-    "react_ujs": "^2.6.1",
-    "turbolinks": "^5.2.0"
+    "react_ujs": "^2.6.1"
   },
   "version": "0.1.0",
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6288,10 +6288,6 @@ tunnel-agent@^0.6.0:
   dependencies:
     safe-buffer "^5.0.1"
 
-turbolinks@^5.2.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/turbolinks/-/turbolinks-5.2.0.tgz#e6877a55ea5c1cb3bb225f0a4ae303d6d32ff77c"
-
 tweetnacl@^0.14.3, tweetnacl@~0.14.0:
   version "0.14.5"
   resolved "https://registry.yarnpkg.com/tweetnacl/-/tweetnacl-0.14.5.tgz#5ae68177f192d4456269d108afa93ff8743f4f64"


### PR DESCRIPTION
Turbolinks caching prevented the React components from rendering except on reload. Using `turbolinks:load` fixed that, but then started persisting the components when navigating to other pages. So I scrapped it.